### PR TITLE
Documentation had the wrong value for unknown domains

### DIFF
--- a/service-scripts/rast_call_CDSs_using_prodigal.pl
+++ b/service-scripts/rast_call_CDSs_using_prodigal.pl
@@ -65,10 +65,10 @@ my $contigs      = [ map { [ $_->{id}, undef, $_->{dna} ] }  @ { $genomeTO->{con
 
 my $params = { -contigs      => $contigs,
 	       -genetic_code => $genetic_code,
-		   -mode         => 'normal',
+	       -mode         => 'normal',
 	       };
 if ($genomeTO->{domain} !~ m/^([ABV])/o) {
-    $params->{-mode} = 'anon';  # Anonymous sequences and metagenomes
+    $params->{-mode} = 'meta';  # Anonymous sequences and metagenomes
 }
 
 if ($temp_dir) { $params->{-tmpdir} = $temp_dir; }


### PR DESCRIPTION
@scanon 
The Prodigal documentation said to use 'anon' but the right value is 'meta'. The documentation had been revised in anticipation of a version change that never happened.

https://groups.google.com/forum/#!topic/prodigal-discuss/C8-gIkaWSmg